### PR TITLE
feat(core):archive subscription

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,67 @@
+# Notes around Production Release
+
+## General
+
+In this section, I describe some of the issues I encountered, which fundamented some od the thoughts conveyed in this document. 
+
+The implementation of the call filter feature is not the best. This is due to the the gql api not allowing for sorting calls by date. This not being possible, I fetched as much of the available data into the frontend, in order to sort the data and group it into days. The filtering of data based on call origin, and type(voicemail, answered, missed) is also being done in the frontend. 
+
+### Caching
+
+Ideally, the sorting and filtering by call type would be available in the gql endpoints, thereby eliminating the need to perform expensive sort/filter operations in the frontend. While the volume of calls processed is not significant, the current option does not scale well for a large number of calls, (or at least, this is not a solution I like - filtering/sorting data in the frontend; I prefer that for larger sets of data, as much data processing is done on the backend)
+
+Additionally, being able to perform these operations in the gql server, would allow us to also leverage query caching, in a more efficient manner, for instance, using something like readQuery, where we would query data that we had previously cached using ApolloGraphQL.
+
+### Libraries Used
+
+The project is using some outdated libraries. These are the libraries which are currently outdated (obtained running yarn outdated):
+
+@aircall/tractor            2.0.0-next.13 2.0.0-next.13 3.0.34  dependencie
+@testing-library/jest-dom   5.17.0        5.17.0        6.4.2   dependencies https://github.com/testing-library/jest-dom#readme
+@testing-library/react      13.4.0        13.4.0        15.0.5  dependencies https://github.com/testing-library/react-testing-library#readme
+@testing-library/user-event 13.5.0        13.5.0        14.5.2  dependencies https://github.com/testing-library/user-event#readme
+@types/jest                 27.5.2        27.5.2        29.5.12 dependencies https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/jest
+@types/node                 16.18.96      16.18.96      20.12.7 dependencies https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node
+date-fns                    2.30.0        2.30.0        3.6.0   dependencies https://github.com/date-fns/date-fns#readme
+husky                       8.0.3         8.0.3         9.0.11  dependencies https://github.com/typicode/husky#readme
+lint-staged                 13.3.0        13.3.0        15.2.2  dependencies https://github.com/okonet/lint-staged#readme
+prettier                    2.8.8         2.8.8         3.2.5   dependencies https://prettier.io
+styled-components           5.3.11        5.3.11        6.1.9   dependencies https://styled-components.com
+typescript                  4.9.5         4.9.5         5.4.5   dependencies https://www.typescriptlang.org/
+web-vitals                  2.1.4         2.1.4         3.5.2   dependencies https://github.com/GoogleChrome/web-vitals#readme
+
+The development of this feature could serve as an opportunity to try and update some of these libraries, and if there aren't any significant changes, these updates could be incorporated into a separate PR, which would be merged into master, just ahead of the merge of the new feature.
+
+For more complicated upgrades (for instance, upgrading UI libraries can many times pose a problem, and can lead to a situation in which we might have tow differing versions of the same library in the codebase), these should be flagged and a backlog item for updating these libraries, should be planned. 
+
+I prefer to have updated library versions, as much as possible, for handling security issues that may arise, out of using these outdated libraries, as well as ensuring that we get the latest benefits that newer library versions might confer.
+
+There is also a deprecation notice in the library being used for websocket communication with GraphQL: `subscriptions-transport-ws`. This library should be replaced with the recommended library.
+
+### Testing 
+
+#### Unit Tests
+
+Some tests were written with regard to the time helper functions, but some more tests should be put together, in order to get better converage on edge cases that might've been missed. We should also add tests that can ensure that the websocket updates are working as expected, without relying exclusively on Cypress, as there are some aspects that need to be tested, which could result in test flakiness in cypress and lead to false positives, impacting negatively the CI/CD process.
+
+#### Accessibility Tests
+
+The features put together, while functional could be improved with regards to supporting accessibility. Some manual tests would have to be conducted in order to ensure that correct tab order is maintained on the feature, and that all features can be activated using only keyboard navigation. During this phase, tests that can be automated, should be identified and written. These tests would check for the existence of correct attributes and the usage of semantic html. 
+
+#### E2E Tests
+
+Right now, only basic features are covered. Additional tests covering other scenarios, should be added, such as guaranteeing that the websocket archiving feature works as expected, on simulatneous browser tabs.
+
+While this aspect is not strictly related to E2E testing, we should also put together some tests that check for UI layout consistency, so that in the future, if any other features are added or removed, we can be assured that no unintentional UI breakage occurs. 
+
+These specific tests could then be added to the CI/CD pipeline, before a feature is merged.
+
+### Improvements
+
+We should identify components of a given feature that can be converted into reusable components. This might be hard to do during implementation, but it is something to be aware during development.
+
+The Calls archive, at the moment shows all calls in the same interface, the distinguishing feature being a change in the card color and the button that archives the calls. A better alternative would be to have archived calls be displayed in a separate tab, and only have them be displayed in the general calls list, if a user unarchives the calls, from the archived view tab. 
+
+We should also allow users to select multiple calls and archive/unarchive them in a single operation, rather than having the user click on each call he intends to operate on.
+
+The documentation of the Tractor Design System, could be improved, in order to include more information on the best way to use the components of this library. For instance, some samples showing the integration of various components, in some scenarios, would facilitate the ramp up and usage of this library.

--- a/phone-test/cypress/e2e/1-login-logout/auth_and_logout.cy.js
+++ b/phone-test/cypress/e2e/1-login-logout/auth_and_logout.cy.js
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 
 
-describe('Test Authentication', () => {
+describe('Test Authentication and Logout', () => {
   beforeEach(() => {
     cy.visit('http://localhost:3000/login')
     cy.get('#email').type('joe@aircall.io');
@@ -22,7 +22,8 @@ describe('Test Authentication', () => {
     cy.contains('logout').should('be.visible');
     cy.contains(/calls history/i).should('be.visible');
     cy.get('[data-testid="call-card"]').eq(1).click();
-    cy.get('[data-testid="call-detail-card"]').should('be.visible');
+    cy.contains(/calls archived/i).should('be.visible');
+    // cy.get('[data-testid="call-detail-card"]').should('be.visible');
   })
 
   it('successfully logs out', () => {

--- a/phone-test/cypress/e2e/2-call-archival/call_archival.cy.js
+++ b/phone-test/cypress/e2e/2-call-archival/call_archival.cy.js
@@ -1,0 +1,27 @@
+/// <reference types="cypress" />
+
+
+describe('Test Call Archival', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:3000/login')
+    cy.get('#email').type('joe@aircall.io');
+    cy.get('#password').type('pass');
+    cy.findByRole('button', {
+      name: /login/i
+    }).click();
+    
+  })
+  it('clicking on unarchived call should archive call', () => {
+    cy.get('[data-testid="call-archival-button"]').should('have.length', 5);
+    cy.get('[data-testid="unarchived-call-card"]').first().find('[data-testid="call-archival-button"]').click();
+    cy.get('[data-test="toast-success"]').should('be.visible');
+    cy.get('[data-test="toast-success"]').contains('Call archived')
+  })
+
+  it('clicking on archived call should unarchive call', () => {
+    cy.get('[data-testid="call-archival-button"]').should('have.length', 5);
+    cy.get('[data-testid="archived-call-card"]').first().find('[data-testid="call-archival-button"]').click();
+    cy.get('[data-test="toast-success"]').should('be.visible');
+    cy.get('[data-test="toast-success"]').contains('Call unarchived')
+  })
+})

--- a/phone-test/package.json
+++ b/phone-test/package.json
@@ -23,6 +23,7 @@
     "react-router-dom": "^6.4.3",
     "react-scripts": "5.0.1",
     "styled-components": "^5.3.6",
+    "subscriptions-transport-ws": "^0.11.0",
     "typescript": "^4.4.2",
     "web-vitals": "^2.1.0"
   },

--- a/phone-test/src/gql/archiveCallSubscription/archiveCallSubscription.ts
+++ b/phone-test/src/gql/archiveCallSubscription/archiveCallSubscription.ts
@@ -1,0 +1,11 @@
+import { gql } from '@apollo/client';
+import { CALL_FIELDS } from '../fragments';
+
+export const CALLS_SUBSCRIPTION = gql`
+  ${CALL_FIELDS}
+  subscription onUpdateCal {
+    onUpdatedCall {
+      ...CallFields
+    }
+  }
+`;

--- a/phone-test/src/gql/archiveCallSubscription/index.ts
+++ b/phone-test/src/gql/archiveCallSubscription/index.ts
@@ -1,0 +1,1 @@
+export * from './archiveCallSubscription'

--- a/phone-test/src/gql/client/consts.ts
+++ b/phone-test/src/gql/client/consts.ts
@@ -1,0 +1,2 @@
+export const HTTP_GRAPHQL_ENDPOINT = 'https://frontend-test-api.aircall.dev/graphql';
+export const WS_GRAPHQL_ENDPOINT = 'wss://frontend-test-api.aircall.dev/websocket';

--- a/phone-test/src/gql/client/helpers.ts
+++ b/phone-test/src/gql/client/helpers.ts
@@ -1,0 +1,23 @@
+import { SubscriptionClient } from 'subscriptions-transport-ws';
+import { getMainDefinition } from '@apollo/client/utilities';
+import { Kind, OperationTypeNode } from 'graphql';
+import { Operation } from '@apollo/client';
+
+export const getWsClient = (ws_connection: string) => new SubscriptionClient(ws_connection, {
+    lazy: true,
+    reconnect: true,
+    connectionParams: () => {
+      const accessToken = localStorage.getItem('access_token') ? JSON.parse(localStorage.getItem('access_token')!) : null;
+      return {
+        authorization: accessToken ? `Bearer ${accessToken}` : ''
+      };
+    }
+  });
+
+  export const isWebsocketSubscription = (operation: Operation) => {
+    const definition = getMainDefinition(operation.query);
+    return (
+      definition.kind === Kind.OPERATION_DEFINITION &&
+      definition.operation === OperationTypeNode.SUBSCRIPTION
+    );
+  }

--- a/phone-test/src/gql/mutations/archiveCall.ts
+++ b/phone-test/src/gql/mutations/archiveCall.ts
@@ -1,0 +1,11 @@
+import { gql } from '@apollo/client';
+import { CALL_FIELDS } from '../fragments';
+
+export const ARCHIVE_CALL = gql`
+  ${CALL_FIELDS}
+  mutation ArchiveCall($id: ID!) {
+    archiveCall(id: $id) {
+      ...CallFields
+    }
+  }
+`;

--- a/phone-test/src/gql/mutations/index.ts
+++ b/phone-test/src/gql/mutations/index.ts
@@ -1,2 +1,3 @@
 export * from './login';
 export * from './refreshToken';
+export * from './archiveCall'

--- a/phone-test/src/pages/CallDetail/CallDetail.decl.ts
+++ b/phone-test/src/pages/CallDetail/CallDetail.decl.ts
@@ -7,7 +7,9 @@ export interface CallDetailProps {
       to: string;
       duration: number;
       created_at: string;
+      is_archived: boolean;
       notes?: string[];
+      via:string;
     };
     onClick: (id: string) => void;
   }

--- a/phone-test/src/pages/CallDetail/CallDetail.tsx
+++ b/phone-test/src/pages/CallDetail/CallDetail.tsx
@@ -69,7 +69,7 @@ export const CallDetail: React.FC<CallDetailProps> = ({ call, onClick }) => {
   const notes = call.notes ? `Call has ${call.notes.length} notes` : <></>;
 
   return (
-    <Spacer space={3} direction="vertical" fluid data-testid={`call-card`}>
+    <Spacer space={3} direction="vertical" fluid data-testid={`${call.is_archived ? 'archived' : 'unarchived'}-call-card`}>
       <Box
         minWidth="1"
         key={call.id}
@@ -107,6 +107,7 @@ export const CallDetail: React.FC<CallDetailProps> = ({ call, onClick }) => {
                 <Icon key={call.id} component={SpinnerOutlined} spin />
               ) : (
                 <IconButton
+                  data-testid={`call-archival-button`}
                   key={call.id}
                   size={24}
                   component={call.is_archived ? ArchiveFilled : ArchiveOutlined}

--- a/phone-test/src/pages/CallDetail/CallDetail.tsx
+++ b/phone-test/src/pages/CallDetail/CallDetail.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import {
   Grid,
   Icon,
@@ -7,13 +7,55 @@ import {
   Box,
   DiagonalDownOutlined,
   DiagonalUpOutlined,
+  Tooltip,
+  ArchiveFilled,
+  ArchiveOutlined,
+  IconButton,
+  SpinnerOutlined,
+  useToast
 } from '@aircall/tractor';
+import { useMutation } from '@apollo/client';
 
+import { ARCHIVE_CALL } from '../../gql/mutations';
+import { CallDetailProps } from './CallDetail.decl';
 import { formatDate, formatDuration } from '../../helpers/dates';
 
-import { CallDetailProps } from './CallDetail.decl';
-
 export const CallDetail: React.FC<CallDetailProps> = ({ call, onClick }) => {
+  let archivingCallId = useRef<string | undefined>();
+  const ARCHIVE_OPERATION = 'ARCHIVE_OPERATION';
+
+  const { showToast, removeToast } = useToast();
+  const [archiveMutation] = useMutation(ARCHIVE_CALL);
+
+  const handleArchiveCall = (call: Call) => {
+    const { id } = call;
+
+    removeToast(ARCHIVE_OPERATION);
+    archivingCallId.current = id;
+
+    archiveMutation({
+      variables: {
+        id
+      },
+      onCompleted: ({ archiveCall }) => {
+        archivingCallId.current = undefined;
+        showToast({
+          id: ARCHIVE_OPERATION,
+          message: archiveCall.is_archived ? 'Call archived' : 'Call unarchived',
+          variant: 'success'
+        });
+      },
+      onError: () => {
+        archivingCallId.current = undefined;
+        showToast({
+          id: ARCHIVE_OPERATION,
+          message: 'Error while archiving call',
+          variant: 'error'
+        });
+      }
+    });
+  };
+
   const icon = call.direction === 'inbound' ? DiagonalDownOutlined : DiagonalUpOutlined;
   const title =
     call.call_type === 'missed'
@@ -31,7 +73,7 @@ export const CallDetail: React.FC<CallDetailProps> = ({ call, onClick }) => {
       <Box
         minWidth="1"
         key={call.id}
-        bg="black-a30"
+        bg={call.is_archived ? '#C9DFDB' : 'black-a10'}
         borderRadius={16}
         cursor="pointer"
         onClick={() => onClick(call.id)}
@@ -59,6 +101,24 @@ export const CallDetail: React.FC<CallDetailProps> = ({ call, onClick }) => {
             </Typography>
             <Typography variant="caption">{date}</Typography>
           </Box>
+          <Spacer space="s">
+            <Tooltip title={call.is_archived ? 'Unarchive call' : 'Archive call'}>
+              {archivingCallId.current === call.id ? (
+                <Icon key={call.id} component={SpinnerOutlined} spin />
+              ) : (
+                <IconButton
+                  key={call.id}
+                  size={24}
+                  component={call.is_archived ? ArchiveFilled : ArchiveOutlined}
+                  color="#01B288"
+                  onClick={e => {
+                    e.stopPropagation();
+                    handleArchiveCall(call);
+                  }}
+                />
+              )}
+            </Tooltip>
+          </Spacer>
         </Grid>
         <Box px={4} py={2}>
           <Typography variant="caption">{notes}</Typography>

--- a/phone-test/src/pages/CallsList/CallsList.tsx
+++ b/phone-test/src/pages/CallsList/CallsList.tsx
@@ -13,6 +13,8 @@ import { groupCallsIntoPages, filterCalls, sortCallsByDate } from '../helpers';
 import { CallGroup } from './callsList.decl';
 import { CallFilterBar } from './CallFilterBar';
 
+import { CALLS_SUBSCRIPTION } from '../../gql/archiveCallSubscription';
+
 const PaginationWrapper = styled.div`
   > div {
     width: inherit;
@@ -36,8 +38,12 @@ const CallsListPage = () => {
   const [totalFilteredCalls, setTotalFilteredCalls] = useState(0);
   const [paginatedCalls, setPaginatedCalls] = useState<CallGroup[]>([]);
 
-  const { loading, error, data } = useQuery(PAGINATED_CALLS, {
+  const { loading, error, data, subscribeToMore } = useQuery(PAGINATED_CALLS, {
     variables: { offset: 0, limit: 200 }
+  });
+
+  subscribeToMore({
+    document: CALLS_SUBSCRIPTION
   });
 
   useEffect(() => {

--- a/phone-test/yarn.lock
+++ b/phone-test/yarn.lock
@@ -3303,6 +3303,11 @@ babel-preset-react-app@^10.0.1:
     babel-plugin-macros "^3.1.0"
     babel-plugin-transform-react-remove-prop-types "^0.4.24"
 
+backo2@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
+  integrity sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
@@ -5087,6 +5092,11 @@ eventemitter2@6.4.7:
   resolved "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz"
   integrity sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==
 
+eventemitter3@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+  integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
+
 eventemitter3@^4.0.0:
   version "4.0.7"
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz"
@@ -6467,6 +6477,11 @@ istanbul-reports@^3.1.3:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+iterall@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
+  integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
 
 iterator.prototype@^1.1.2:
   version "1.1.2"
@@ -10070,6 +10085,17 @@ stylehacks@^5.1.1:
     browserslist "^4.21.4"
     postcss-selector-parser "^6.0.4"
 
+subscriptions-transport-ws@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz#baf88f050cba51d52afe781de5e81b3c31f89883"
+  integrity sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==
+  dependencies:
+    backo2 "^1.0.2"
+    eventemitter3 "^3.1.0"
+    iterall "^1.2.1"
+    symbol-observable "^1.0.4"
+    ws "^5.2.0 || ^6.0.0 || ^7.0.0"
+
 sucrase@^3.32.0:
   version "3.35.0"
   resolved "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz"
@@ -10153,6 +10179,11 @@ svgo@^2.7.0:
     csso "^4.2.0"
     picocolors "^1.0.0"
     stable "^0.1.8"
+
+symbol-observable@^1.0.4:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-observable@^4.0.0:
   version "4.0.0"
@@ -11168,7 +11199,7 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@^7.4.6:
+"ws@^5.2.0 || ^6.0.0 || ^7.0.0", ws@^7.4.6:
   version "7.5.9"
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==


### PR DESCRIPTION
## What it looks like
<img width="829" alt="Screenshot 2024-04-30 at 18 36 35" src="https://github.com/aircall/frontend-hiring-test/assets/7629783/cc0f3f2e-0988-4dac-854a-ccf55e3bda84">

A button is present on the call information card, that when toggled archives and unarchives a call. The background color of the call card changes, according to whether the call is archived or not. 
This PR is based on the work done on this branch: [challenge](https://github.com/jsccosta/frontend-hiring-test/tree/challenge)

### Implementation details
We're leveraging this library `subscriptions-transport-ws` in order to enable socket communication

### Testing
Currently basic e2e tests have been added that check if the call archival and unarchival is applied.
To run these tests run `yarn cypress open` in the `phone-test` folder